### PR TITLE
Fix typo in worker-configuration.d.ts

### DIFF
--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -20,7 +20,7 @@ License at http://www.apache.org/licenses/LICENSE-2.0
 THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
 WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
-MERCHANTABLITY OR NON-INFRINGEMENT.
+MERCHANTABILITY OR NON-INFRINGEMENT.
 See the Apache Version 2.0 License for specific language governing permissions
 and limitations under the License.
 ***************************************************************************** */


### PR DESCRIPTION
## Summary
- correct a typo in a license comment

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: Exit handler never called)*