### PR TITLE
Escape user strings in queries

### DIFF
--- a/src/services.test.ts
+++ b/src/services.test.ts
@@ -200,12 +200,48 @@ describe("AtlassianCommunityServices", () => {
 		);
 	});
 
-	test("getMostRecentBlogPostsByTag should build the correct query", async () => {
-		await getMostRecentBlogPostsByTag("confluence", 10, 0);
+        test("getMostRecentBlogPostsByTag should build the correct query", async () => {
+                await getMostRecentBlogPostsByTag("confluence", 10, 0);
 
-		expect(executeApiRequest).toHaveBeenCalledWith(
-			"SELECT * FROM messages WHERE depth = 0 AND conversation.style = 'blog' AND tags.text = 'confluence' ORDER BY post_time DESC LIMIT 10 OFFSET 0",
-			"getMostRecentBlogPostsByTag",
-		);
-	});
+                expect(executeApiRequest).toHaveBeenCalledWith(
+                        "SELECT * FROM messages WHERE depth = 0 AND conversation.style = 'blog' AND tags.text = 'confluence' ORDER BY post_time DESC LIMIT 10 OFFSET 0",
+                        "getMostRecentBlogPostsByTag",
+                );
+        });
+
+        test("searchByQuery escapes single quotes in search terms", async () => {
+                await searchByQuery("bob's bug", 10, 0, "desc");
+
+                expect(executeApiRequest).toHaveBeenCalledWith(
+                        "SELECT * FROM messages WHERE depth = 0 AND (subject MATCHES 'bob''s bug' OR body MATCHES 'bob''s bug') ORDER BY post_time desc LIMIT 10 OFFSET 0",
+                        "searchByQuery",
+                );
+        });
+
+        test("searchQandAPosts escapes single quotes in search terms", async () => {
+                await searchQandAPosts("can't start", 5, 0, "asc");
+
+                expect(executeApiRequest).toHaveBeenCalledWith(
+                        "SELECT * FROM messages WHERE depth = 0 AND conversation.style = 'qanda' AND (subject MATCHES 'can''t start' OR body MATCHES 'can''t start') ORDER BY post_time asc LIMIT 5 OFFSET 0",
+                        "searchQandAPosts",
+                );
+        });
+
+        test("searchBlogPosts escapes single quotes in search terms", async () => {
+                await searchBlogPosts("atlassian's update", 7, 1, "desc");
+
+                expect(executeApiRequest).toHaveBeenCalledWith(
+                        "SELECT * FROM messages WHERE depth = 0 AND conversation.style = 'blog' AND (subject MATCHES 'atlassian''s update' OR body MATCHES 'atlassian''s update') ORDER BY post_time desc LIMIT 7 OFFSET 1",
+                        "searchBlogPosts",
+                );
+        });
+
+        test("searchByQueryAndTag escapes single quotes in terms and tags", async () => {
+                await searchByQueryAndTag("bob's bug", ["jira", "o'neil"], 3, 2, "asc");
+
+                expect(executeApiRequest).toHaveBeenCalledWith(
+                        "SELECT * FROM messages WHERE depth = 0 AND (subject MATCHES 'bob''s bug' OR body MATCHES 'bob''s bug') AND tags.text IN ('jira', 'o''neil') ORDER BY post_time asc LIMIT 3 OFFSET 2",
+                        "searchByQueryAndTag",
+                );
+        });
 });

--- a/src/services.ts
+++ b/src/services.ts
@@ -8,19 +8,20 @@ import { executeApiRequest, formatSearchResults, formatTagsResults, Logger } fro
  * @param sortOrder Sorting order by post date (asc or desc)
  */
 export async function searchByQuery(
-	searchTerms: string,
-	limit = 25,
-	offset = 0,
-	sortOrder: "asc" | "desc" = "desc",
+        searchTerms: string,
+        limit = 25,
+        offset = 0,
+        sortOrder: "asc" | "desc" = "desc",
 ) {
-	Logger.logRequest("searchByQuery", { searchTerms, limit, offset, sortOrder });
+        Logger.logRequest("searchByQuery", { searchTerms, limit, offset, sortOrder });
 
-	try {
-		// Build the query
-		let query = "SELECT * FROM messages WHERE depth = 0";
+        try {
+                // Build the query
+                let query = "SELECT * FROM messages WHERE depth = 0";
 
-		// Add search terms
-		query += ` AND (subject MATCHES '${searchTerms}' OR body MATCHES '${searchTerms}')`;
+                // Add search terms
+                const sanitizedSearchTerms = searchTerms.replace(/'/g, "''");
+                query += ` AND (subject MATCHES '${sanitizedSearchTerms}' OR body MATCHES '${sanitizedSearchTerms}')`;
 
 		// Add sorting
 		query += ` ORDER BY post_time ${sortOrder}`;
@@ -50,10 +51,10 @@ export async function searchByQuery(
  * @param sortOrder Sorting order by post date (asc or desc)
  */
 export async function searchQandAPosts(
-	searchTerms: string,
-	limit = 25,
-	offset = 0,
-	sortOrder: "asc" | "desc" = "desc",
+        searchTerms: string,
+        limit = 25,
+        offset = 0,
+        sortOrder: "asc" | "desc" = "desc",
 ) {
 	Logger.logRequest("searchQandAPosts", { searchTerms, limit, offset, sortOrder });
 
@@ -62,8 +63,9 @@ export async function searchQandAPosts(
 		// Filter for Q&A posts by specifying conversation.style = 'qanda'
 		let query = "SELECT * FROM messages WHERE depth = 0 AND conversation.style = 'qanda'";
 
-		// Add search terms
-		query += ` AND (subject MATCHES '${searchTerms}' OR body MATCHES '${searchTerms}')`;
+                // Add search terms
+                const sanitizedSearchTerms = searchTerms.replace(/'/g, "''");
+                query += ` AND (subject MATCHES '${sanitizedSearchTerms}' OR body MATCHES '${sanitizedSearchTerms}')`;
 
 		// Add sorting
 		query += ` ORDER BY post_time ${sortOrder}`;
@@ -93,10 +95,10 @@ export async function searchQandAPosts(
  * @param sortOrder Sorting order by post date (asc or desc)
  */
 export async function searchBlogPosts(
-	searchTerms: string,
-	limit = 25,
-	offset = 0,
-	sortOrder: "asc" | "desc" = "desc",
+        searchTerms: string,
+        limit = 25,
+        offset = 0,
+        sortOrder: "asc" | "desc" = "desc",
 ) {
 	Logger.logRequest("searchBlogPosts", { searchTerms, limit, offset, sortOrder });
 
@@ -105,8 +107,9 @@ export async function searchBlogPosts(
 		// Filter for blog posts by specifying conversation.style = 'blog'
 		let query = "SELECT * FROM messages WHERE depth = 0 AND conversation.style = 'blog'";
 
-		// Add search terms
-		query += ` AND (subject MATCHES '${searchTerms}' OR body MATCHES '${searchTerms}')`;
+                // Add search terms
+                const sanitizedSearchTerms = searchTerms.replace(/'/g, "''");
+                query += ` AND (subject MATCHES '${sanitizedSearchTerms}' OR body MATCHES '${sanitizedSearchTerms}')`;
 
 		// Add sorting
 		query += ` ORDER BY post_time ${sortOrder}`;
@@ -137,26 +140,29 @@ export async function searchBlogPosts(
  * @param sortOrder Sorting order by post date (asc or desc)
  */
 export async function searchByQueryAndTag(
-	searchTerms: string,
-	tags: string[],
-	limit = 25,
-	offset = 0,
-	sortOrder: "asc" | "desc" = "desc",
+        searchTerms: string,
+        tags: string[],
+        limit = 25,
+        offset = 0,
+        sortOrder: "asc" | "desc" = "desc",
 ) {
 	Logger.logRequest("searchByQueryAndTag", { searchTerms, tags, limit, offset, sortOrder });
 
 	try {
-		// Build the query
-		let query = "SELECT * FROM messages WHERE depth = 0";
+                // Build the query
+                let query = "SELECT * FROM messages WHERE depth = 0";
 
-		// Add search terms
-		query += ` AND (subject MATCHES '${searchTerms}' OR body MATCHES '${searchTerms}')`;
+                // Add search terms
+                const sanitizedSearchTerms = searchTerms.replace(/'/g, "''");
+                query += ` AND (subject MATCHES '${sanitizedSearchTerms}' OR body MATCHES '${sanitizedSearchTerms}')`;
 
-		// Add tags filter
-		if (tags && tags.length > 0) {
-			const tagsList = tags.map((tag) => `'${tag}'`).join(", ");
-			query += ` AND tags.text IN (${tagsList})`;
-		}
+                // Add tags filter
+                if (tags && tags.length > 0) {
+                        const tagsList = tags
+                                .map((tag) => `'${tag.replace(/'/g, "''")}'`)
+                                .join(", ");
+                        query += ` AND tags.text IN (${tagsList})`;
+                }
 
 		// Add sorting
 		query += ` ORDER BY post_time ${sortOrder}`;


### PR DESCRIPTION
## Summary
- escape single quotes in query builders to prevent malformed SQL
- test that queries properly escape user-provided strings

## Testing
- `npx jest` *(fails: request to registry.npmjs.org/jest failed, EHOSTUNREACH)*