### PR TITLE
Add answered filter options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,15 +22,24 @@ export class MyMCP extends McpAgent {
 	async init() {
 		// 1. Search community posts by query (look for content in all tags)
 		this.server.tool(
-			"searchCommunity",
-			{
-				searchTerms: z.string().min(1),
-				...PaginationSchema,
-				...SortingSchema,
-			},
-			async ({ searchTerms, limit, offset, sortOrder }) => {
-				try {
-					const results = await searchByQuery(searchTerms, limit, offset, sortOrder);
+                        "searchCommunity",
+                        {
+                                searchTerms: z.string().min(1),
+                                answered: z.enum(["answered", "unanswered"]).optional(),
+                                acceptedOnly: z.boolean().optional().default(false),
+                                ...PaginationSchema,
+                                ...SortingSchema,
+                        },
+                        async ({ searchTerms, answered, acceptedOnly, limit, offset, sortOrder }) => {
+                                try {
+                                        const results = await searchByQuery(
+                                                searchTerms,
+                                                limit,
+                                                offset,
+                                                sortOrder,
+                                                answered,
+                                                acceptedOnly,
+                                        );
 					return {
 						content: [{ type: "text", text: JSON.stringify(results) }],
 					};
@@ -51,22 +60,26 @@ export class MyMCP extends McpAgent {
 
 		// 2. Search community posts by query and tags (look for content in specific tags)
 		this.server.tool(
-			"searchByTags",
-			{
-				searchTerms: z.string().optional(),
-				tags: z.array(z.string()).min(1),
-				...PaginationSchema,
-				...SortingSchema,
-			},
-			async ({ searchTerms, tags, limit, offset, sortOrder }) => {
-				try {
-					const results = await searchByQueryAndTag(
-						searchTerms || "",
-						tags,
-						limit,
-						offset,
-						sortOrder,
-					);
+                        "searchByTags",
+                        {
+                                searchTerms: z.string().optional(),
+                                tags: z.array(z.string()).min(1),
+                                answered: z.enum(["answered", "unanswered"]).optional(),
+                                acceptedOnly: z.boolean().optional().default(false),
+                                ...PaginationSchema,
+                                ...SortingSchema,
+                        },
+                        async ({ searchTerms, tags, answered, acceptedOnly, limit, offset, sortOrder }) => {
+                                try {
+                                        const results = await searchByQueryAndTag(
+                                                searchTerms || "",
+                                                tags,
+                                                limit,
+                                                offset,
+                                                sortOrder,
+                                                answered,
+                                                acceptedOnly,
+                                        );
 					return {
 						content: [{ type: "text", text: JSON.stringify(results) }],
 					};

--- a/src/services.test.ts
+++ b/src/services.test.ts
@@ -74,8 +74,8 @@ describe("AtlassianCommunityServices", () => {
 		expect(result.tip).toContain("communityLink");
 	});
 
-	test("searchByQuery should build the correct query", async () => {
-		await searchByQuery("test query", 10, 5, "asc");
+        test("searchByQuery should build the correct query", async () => {
+                await searchByQuery("test query", 10, 5, "asc");
 
 		expect(executeApiRequest).toHaveBeenCalledWith(
 			"SELECT * FROM messages WHERE depth = 0 AND (subject MATCHES 'test query' OR body MATCHES 'test query') ORDER BY post_time asc LIMIT 10 OFFSET 5",
@@ -83,8 +83,8 @@ describe("AtlassianCommunityServices", () => {
 		);
 	});
 
-	test("searchByQueryAndTag should build the correct query with tags", async () => {
-		await searchByQueryAndTag("test query", ["jira", "confluence"], 10, 5, "desc");
+        test("searchByQueryAndTag should build the correct query with tags", async () => {
+                await searchByQueryAndTag("test query", ["jira", "confluence"], 10, 5, "desc");
 
 		expect(executeApiRequest).toHaveBeenCalledWith(
 			"SELECT * FROM messages WHERE depth = 0 AND (subject MATCHES 'test query' OR body MATCHES 'test query') AND tags.text IN ('jira', 'confluence') ORDER BY post_time desc LIMIT 10 OFFSET 5",
@@ -118,6 +118,33 @@ describe("AtlassianCommunityServices", () => {
                 );
 
                 expect(result.items.map((i) => i.viewCount)).toEqual([200, 100, 50]);
+        });
+
+        test("searchByQuery filters answered posts", async () => {
+                await searchByQuery("test query", 10, 0, "desc", "answered", false);
+
+                expect(executeApiRequest).toHaveBeenCalledWith(
+                        "SELECT * FROM messages WHERE depth = 0 AND (subject MATCHES 'test query' OR body MATCHES 'test query') AND reply_count > 0 ORDER BY post_time desc LIMIT 10 OFFSET 0",
+                        "searchByQuery",
+                );
+        });
+
+        test("searchByQueryAndTag filters unanswered posts", async () => {
+                await searchByQueryAndTag("test query", ["jira"], 5, 0, "desc", "unanswered", false);
+
+                expect(executeApiRequest).toHaveBeenCalledWith(
+                        "SELECT * FROM messages WHERE depth = 0 AND (subject MATCHES 'test query' OR body MATCHES 'test query') AND tags.text IN ('jira') AND reply_count = 0 ORDER BY post_time desc LIMIT 5 OFFSET 0",
+                        "searchByQueryAndTag",
+                );
+        });
+
+        test("searchByQuery filters accepted answers", async () => {
+                await searchByQuery("test query", 5, 0, "desc", undefined, true);
+
+                expect(executeApiRequest).toHaveBeenCalledWith(
+                        "SELECT * FROM messages WHERE depth = 0 AND (subject MATCHES 'test query' OR body MATCHES 'test query') AND accepted_solution_id IS NOT NULL ORDER BY post_time desc LIMIT 5 OFFSET 0",
+                        "searchByQuery",
+                );
         });
 
 	test("getMostRecentPosts should build the correct query", async () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -92,9 +92,10 @@ export function formatPost(post: any) {
 	const hasAcceptedSolution = post.acceptedSolutionId ? true : false;
 
 	// Determine content type (blog or q&a)
-	const contentType = post.conversation?.style || "unknown";
-	const isBlog = contentType === "blog";
-	const isQandA = contentType === "qanda";
+        const contentType = post.conversation?.style || "unknown";
+        const isBlog = contentType === "blog";
+        const isQandA = contentType === "qanda";
+        const isArticle = contentType === "article";
 
 	// Construct a more user-friendly URL
 	// Format: https://community.atlassian.com/t5/[board-id]/[post-title]/td-p/[post-id]
@@ -118,9 +119,10 @@ export function formatPost(post: any) {
 		viewCount,
 		replyCount,
 		hasAcceptedSolution,
-		contentType,
-		isBlog,
-		isQandA,
+                contentType,
+                isBlog,
+                isQandA,
+                isArticle,
 		url,
 		communityLink: url, // Add a more explicit property for the link
 		excerpt,


### PR DESCRIPTION
## Summary
- add `answered` and `acceptedOnly` options to search functions
- expose these filters via `searchCommunity` and `searchByTags` tools
- record tests for answered/unanswered and accepted answer queries
- include `isArticle` flag in formatted post objects

## Testing
- `npm run format` *(fails: biome not found)*
- `npm test` *(fails: jest not found)*